### PR TITLE
Update K10 TestDrive Instruqt lab to use image: instruqt-k8s-testdrive-02-2022-v2

### DIFF
--- a/k10-testdrive/config.yml
+++ b/k10-testdrive/config.yml
@@ -1,6 +1,6 @@
 version: "2"
 virtualmachines:
 - name: k8svm
-  image: k10-gke-testdrive-180621/instruqt-k8s-testdrive-08-23-2021
+  image: k10-gke-testdrive-180621/instruqt-k8s-testdrive-02-2022-v2
   shell: /bin/bash
   machine_type: n1-standard-4


### PR DESCRIPTION
Update K10 TestDrive Instruqt lab to use Michael's image as a stopgap while we develop a new image.